### PR TITLE
Report commands without an exec function

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,13 +34,12 @@ func main() {
 		err    = exec(ctx, args, stdin, stdout, stderr)
 	)
 	switch {
-	case err == nil, errors.Is(err, ff.ErrHelp), errors.Is(err, ff.ErrNoExec):
+	case err == nil, errors.Is(err, ff.ErrHelp):
 		// Nothing to do.
 	default:
 		// Special handling for exec errors when running commands.
-		var exitErr *osexec.ExitError
-		if errors.As(err, &exitErr) {
-			os.Exit(exitErr.ExitCode())
+		if code := exitError(err); code > -1 {
+			os.Exit(code)
 		}
 
 		fmt.Fprintf(stderr, "Command failed: %v.\n", err)
@@ -91,4 +90,12 @@ func exec(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io
 	}
 
 	return nil
+}
+
+func exitError(err error) int {
+	var exitErr *osexec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }

--- a/testdata/root.txtar
+++ b/testdata/root.txtar
@@ -3,3 +3,12 @@ setup
 ! exec bine --invalid
 ! stdout .
 stderr 'bine helps manage external binary tools needed for development projects'
+
+# Confirm error handling when subcommand (exit function) doesn't exist.
+setup
+! exec bine subcmd
+! stdout .
+cmp stderr ../noexec.txt
+
+-- noexec.txt --
+Command failed: bine: no exec function.

--- a/testdata/run.txtar
+++ b/testdata/run.txtar
@@ -1,11 +1,22 @@
 setup .bine.json
 
+# Requires name of the binary as an argument.
 ! bine run
 ! stdout .
 stderr 'run requires one argument'
 
+# Forwards the standard streams of the child process.
 bine run perpignan
+! stdout .
 stderr 'hello world\!'
+
+# Forwards the exit code of the child process.
+bine run leucate 0
+! stdout .
+! stderr .
+! bine run leucate 1
+! stdout .
+! stderr .
 
 -- .bine.json --
 {
@@ -14,6 +25,12 @@ stderr 'hello world\!'
         {
             "name": "perpignan",
             "url": "https://github.com/sevein/perpignan",
+            "version": "1.0.0",
+            "asset_pattern": "{name}_{version}_{goos}_{goarch}"
+        },
+        {
+            "name": "leucate",
+            "url": "https://github.com/sevein/leucate",
             "version": "1.0.0",
             "asset_pattern": "{name}_{version}_{goos}_{goarch}"
         }


### PR DESCRIPTION
This commit ensures that an error is reported when running a command without an exec function, e.g. `bine foobar`. Some tests have been added to confirm that the exit code is forwarded when using `bine rune`.