### PR TITLE
Add support for modifiers during expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ The following variables are supported:
 * `{arch}`: The machine hardware name as reported by `uname -m` (e.g., `x86_64`,
   `arm64`).
 
+Use `modifiers` if you want to change some values after expansion, e.g.:
+
+```json
+{
+    "project": "test",
+    "bins": [
+        {
+            "name": "grpcurl",
+            "url": "https://github.com/fullstorydev/grpcurl",
+            "version": "1.9.3",
+            "asset_pattern": "{name}_{version}_{goos}_{goarch}.tar.gz",
+            "modifiers": {
+                "goos": {
+                    "darwin": "osx"
+                },
+                "goarch": {
+                    "amd64": "x86_64"
+                }
+            }
+        }
+    ]
+}
+```
+
 ## Authenticating to the GitHub Rest API
 
 If you downloading binaries from GitHub, you may need to authenticate to the

--- a/bine/bin.go
+++ b/bine/bin.go
@@ -25,6 +25,9 @@ type bin struct {
 	// Field for go-based installs.
 	GoPackage string `json:"go_package,omitempty"`
 
+	// Allows to apply modifications during variable expansion.
+	Modifiers map[string]map[string]string `json:"modifiers,omitempty"`
+
 	// asset is computed by the namer when the config is loaded.
 	asset string
 

--- a/bine/bine.go
+++ b/bine/bine.go
@@ -158,7 +158,13 @@ func (b *Bine) load(name string) (*bin, error) {
 }
 
 // install ensures that the given binary is installed.
-func (b *Bine) install(ctx context.Context, bin *bin) (string, error) {
+func (b *Bine) install(ctx context.Context, bin *bin) (_ string, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("%q: %v", bin.Name, err)
+		}
+	}()
+
 	binPath := filepath.Join(b.BinDir, bin.Name)
 
 	// If version marker exists, assume binary is already installed.

--- a/testdata/run.txtar
+++ b/testdata/run.txtar
@@ -11,6 +11,7 @@ bine run perpignan
 stderr 'hello world\!'
 
 # Forwards the exit code of the child process.
+# Notice that the installation of leucate required modifiers.
 bine run leucate 0
 ! stdout .
 ! stderr .
@@ -32,7 +33,12 @@ bine run leucate 0
             "name": "leucate",
             "url": "https://github.com/sevein/leucate",
             "version": "1.0.0",
-            "asset_pattern": "{name}_{version}_{goos}_{goarch}"
+            "asset_pattern": "{name}_{version}_{goos}_{goarch}",
+            "modifiers": {
+	        "goos": {
+		    "darwin": "osx"
+		}
+            }
         }
     ]
 }


### PR DESCRIPTION
Small fixes I've needed while using bine in CCP.

* ffe2a3639e0e158dff46db63677f179ba7fe9a5a allows me to download `grpccurl`.
* 2262f0bceee27c44d3a4f390bc166958119b6424 allows me to download `buf` from MacOS.