### PR TITLE
Add support for rustc triples and custom tag patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ are Go modules installable via `go install`.
 For an example, check out how the [`make`] uses bine to install a binary
 directly from a Go module.
 
-### Variable expansion
+### Asset patterns
 
-The `asset_pattern` field in the configuration supports variable expansion to help construct the correct asset filename for download. Bine replaces placeholders within this pattern based on the binary's definition and the environment where `bine` is run.
+The `asset_pattern` field in the configuration supports variable expansion to
+help construct the correct asset filename for download. Bine replaces
+placeholders within this pattern based on the binary's definition and the
+environment where `bine` is run.
 
 The following variables are supported:
 
@@ -98,6 +101,7 @@ The following variables are supported:
   `Darwin`).
 * `{arch}`: The machine hardware name as reported by `uname -m` (e.g., `x86_64`,
   `arm64`).
+* `{triple}` The "target triple" used in rustc.
 
 Use `modifiers` if you want to change some values after expansion, e.g.:
 
@@ -122,6 +126,36 @@ Use `modifiers` if you want to change some values after expansion, e.g.:
     ]
 }
 ```
+
+### Tag patterns
+
+Similarly, the `tag_pattern` field supports variable expansion to help construct
+the correct tag used to fetch the binary from GitHub releases.
+
+For example:
+
+```json
+{
+    "project": "test",
+    "bins": [
+        {
+            "name": "jq",
+            "url": "https://github.com/jqlang/jq",
+            "version": "1.7.1",
+            "asset_pattern": "{name}-{goos}-{goarch}",
+            "tag_pattern": "{name}-{version}",
+            "modifiers": {
+              "goos": {
+                "darwin": "macos"
+              }
+            }
+        }
+    ]
+}
+```
+
+This is necessary because jq names its tags like `jq-1.8.0`, as opposed to the
+most common `v1.8.0` style seen in many other projects.
 
 ## Authenticating to the GitHub Rest API
 

--- a/bine/bin_test.go
+++ b/bine/bin_test.go
@@ -7,7 +7,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestBin(t *testing.T) {
+func TestBinVersions(t *testing.T) {
 	tests := []struct {
 		version    string // Provided by the user (we want to be flexible).
 		canonical  string
@@ -26,6 +26,29 @@ func TestBin(t *testing.T) {
 			assert.Equal(t, b.canonicalVersion(), test.canonical)
 			assert.Equal(t, b.usableVersion(), test.usable)
 			assert.Equal(t, b.unprefixedVersion(), test.unprefixed)
+		})
+	}
+}
+
+func TestBinTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		tagPattern  string
+		expectedTag string
+	}{
+		{"Default pattern", "1.2.3", "", "v1.2.3"},
+		{"uv style: no prefix", "0.7.11", "{version}", "0.7.11"},
+		{"jq style: prefix", "1.8.0", "jq-{version}", "jq-1.8.0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := bin{
+				Version:    test.version,
+				TagPattern: test.tagPattern,
+			}
+			assert.Equal(t, b.tag(), test.expectedTag)
 		})
 	}
 }

--- a/bine/cmd.go
+++ b/bine/cmd.go
@@ -1,0 +1,6 @@
+package bine
+
+import "os/exec"
+
+// execCommand can be replaced in tests to inject a fake command function.
+var execCommand = exec.CommandContext

--- a/bine/cmd_test.go
+++ b/bine/cmd_test.go
@@ -1,0 +1,26 @@
+package bine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func fakeExecCommand(t *testing.T, testHelperName string) func(ctx context.Context, command string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, command string, args ...string) *exec.Cmd {
+		cs := []string{fmt.Sprintf("-test.run=%s", testHelperName), "--", command}
+		cs = append(cs, args...)
+		t.Logf("Preparing *exec.Cmd using test binary %q with args: %v", os.Args[0], cs)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+		return cmd
+	}
+}
+
+func injectFakeExec(t *testing.T, testHelperName string) {
+	t.Helper()
+	execCommand = fakeExecCommand(t, testHelperName)
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+}

--- a/bine/install.go
+++ b/bine/install.go
@@ -19,8 +19,6 @@ import (
 
 // Supporting functions for installing binaries.
 
-var execCommand = exec.CommandContext
-
 // goInstall installs a Go tool using 'go install'.
 //
 // TODO: honour binPath - name the binary following the user's preference.

--- a/bine/install_test.go
+++ b/bine/install_test.go
@@ -1,32 +1,12 @@
 package bine
 
 import (
-	"context"
-	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
-
-func fakeExecCommand(t *testing.T, testHelperName string) func(ctx context.Context, command string, args ...string) *exec.Cmd {
-	return func(ctx context.Context, command string, args ...string) *exec.Cmd {
-		cs := []string{fmt.Sprintf("-test.run=%s", testHelperName), "--", command}
-		cs = append(cs, args...)
-		t.Logf("Preparing *exec.Cmd using test binary %q with args: %v", os.Args[0], cs)
-		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
-		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-		return cmd
-	}
-}
-
-func injectFakeExec(t *testing.T, testHelperName string) {
-	t.Helper()
-	execCommand = fakeExecCommand(t, testHelperName)
-	t.Cleanup(func() { execCommand = exec.CommandContext })
-}
 
 func TestHelperProcessWithSuccess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {

--- a/bine/namer.go
+++ b/bine/namer.go
@@ -1,0 +1,220 @@
+package bine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var (
+	goos   = runtime.GOOS
+	goarch = runtime.GOARCH
+)
+
+// namer computes the asset names defined in the configuration.
+type namer struct {
+	// uname operative system: `uname -s`, e.g. "Linux", "Darwin"...
+	unameOS string
+	// uname machine hardware name: `uname -m`, e.g. "x86_64", "arm64"...
+	unameArch string
+	// rustc target triple: `rustc -vV | sed -n -e 's/^host: //p'`, e.g. "x86_64-unknown-linux-gnu"
+	triple string
+}
+
+func createNamer() (*namer, error) {
+	n := namer{}
+
+	ctx := context.TODO()
+
+	out, err := execCommand(ctx, "uname", "-s").Output()
+	if err != nil {
+		return nil, fmt.Errorf("uname: %v", err)
+	}
+	n.unameOS = strings.TrimSpace(string(out))
+
+	out, err = execCommand(ctx, "uname", "-m").Output()
+	if err != nil {
+		return nil, fmt.Errorf("uname: %v", err)
+	}
+	n.unameArch = strings.TrimSpace(string(out))
+
+	if t := triple(ctx); t == "" {
+		return nil, errors.New("unable to determine rustc target triple")
+	} else {
+		n.triple = t
+	}
+
+	return &n, nil
+}
+
+func (n *namer) run(bins []*bin) {
+	if n == nil {
+		return
+	}
+	for _, b := range bins {
+		if b.goPkg() {
+			continue
+		}
+		asset := b.AssetPattern
+		asset = strings.ReplaceAll(asset, "{name}", b.Name)
+		asset = strings.ReplaceAll(asset, "{version}", b.unprefixedVersion())
+		asset = strings.ReplaceAll(asset, "{goos}", n.applyModifier(b, "goos", goos))
+		asset = strings.ReplaceAll(asset, "{goarch}", n.applyModifier(b, "goarch", goarch))
+		asset = strings.ReplaceAll(asset, "{os}", n.applyModifier(b, "os", n.unameOS))
+		asset = strings.ReplaceAll(asset, "{arch}", n.applyModifier(b, "arch", n.unameArch))
+		asset = strings.ReplaceAll(asset, "{triple}", n.triple)
+
+		b.asset = asset
+	}
+}
+
+// applyModifier applies template variable modifiers if they exist for the
+// given variable, e.g.: when expanding {goos}, the user chooses to replaceAdd commentMore actions
+// "darwin" with "osx".
+func (n *namer) applyModifier(b *bin, variable, originalValue string) string {
+	if b.Modifiers == nil {
+		return originalValue
+	} else if modifierMap, exists := b.Modifiers[variable]; !exists {
+		return originalValue
+	} else if modifiedValue, exists := modifierMap[originalValue]; exists {
+		return modifiedValue
+	}
+
+	return originalValue
+}
+
+func triple(ctx context.Context) string {
+	// First try to get triple from rustc.
+	out, err := execCommand(ctx, "rustc", "-vV").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(line, "host: ") {
+				triple := strings.TrimSpace(strings.TrimPrefix(line, "host: "))
+				if triple != "" {
+					return triple
+				}
+			}
+		}
+	}
+
+	// Inline arch mapping
+	goarch := runtime.GOARCH
+	arch := goarch
+	switch goarch {
+	case "amd64", "x86_64":
+		arch = "x86_64"
+	case "386", "i386", "i686":
+		arch = "i686"
+	case "arm64", "aarch64":
+		arch = "aarch64"
+	case "armv7l":
+		arch = "armv7"
+	case "arm":
+		if v, _ := strconv.Atoi(os.Getenv("GOARM")); v >= 7 {
+			arch = "armv7"
+		} else {
+			arch = "arm"
+		}
+	case "ppc64":
+		arch = "powerpc64"
+	case "ppc64le":
+		arch = "powerpc64le"
+	case "s390x":
+		arch = "s390x"
+	case "riscv64":
+		arch = "riscv64"
+	}
+
+	// Inline vendor mapping
+	goos := runtime.GOOS
+	vendor := "unknown"
+	switch goos {
+	case "darwin":
+		vendor = "apple"
+	case "windows":
+		vendor = "pc"
+	case "android":
+		vendor = "linux"
+	}
+
+	// Inline system mapping
+	sys := goos
+	switch goos {
+	case "darwin":
+		sys = "darwin"
+	case "windows":
+		sys = "windows"
+	case "linux":
+		sys = "linux"
+	case "android":
+		sys = "android"
+	case "freebsd":
+		sys = "freebsd"
+	case "openbsd":
+		sys = "openbsd"
+	case "netbsd":
+		sys = "netbsd"
+	case "dragonfly":
+		sys = "dragonfly"
+	case "illumos":
+		sys = "illumos"
+	}
+
+	// Inline abi mapping
+	abi := ""
+	switch goos {
+	case "windows":
+		abi = "msvc"
+	case "linux":
+		// Inline musl detection
+		isMusl := false
+		if _, err := os.Stat("/etc/alpine-release"); err == nil {
+			isMusl = true
+		} else {
+			dirs := []string{"/lib", "/usr/lib", "/lib64", "/usr/lib64"}
+			found := false
+			for _, d := range dirs {
+				_ = filepath.WalkDir(d, func(path string, _ os.DirEntry, _ error) error {
+					if strings.HasPrefix(filepath.Base(path), "ld-musl") {
+						found = true
+						return fmt.Errorf("found-musl")
+					}
+					return nil
+				})
+				if found {
+					isMusl = true
+					break
+				}
+			}
+			if !isMusl {
+				out, err := exec.Command("ldd", "--version").CombinedOutput()
+				if err == nil && bytes.Contains(out, []byte("musl")) {
+					isMusl = true
+				}
+			}
+		}
+		if isMusl {
+			abi = "musl"
+		} else {
+			abi = "gnu"
+		}
+	}
+
+	// Assemble the triple; omit empty vendor or abi to avoid double dashes.
+	triple := arch
+	if vendor != "" {
+		triple += "-" + vendor
+	}
+	triple += "-" + sys
+	if abi != "" {
+		triple += "-" + abi
+	}
+	return triple
+}

--- a/bine/namer_test.go
+++ b/bine/namer_test.go
@@ -1,0 +1,67 @@
+package bine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHelperRustcTriple(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := strings.Join(os.Args, " ")
+	if strings.Contains(args, "uname -s") {
+		fmt.Println("Linux")
+	} else if strings.Contains(args, "uname -m") {
+		fmt.Println("x86_64")
+	} else {
+		fmt.Println("x86_64-unknown-linux-gnu")
+	}
+
+	os.Exit(0)
+}
+
+func TestHelperRustcFailed(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := strings.Join(os.Args, " ")
+	if strings.Contains(args, "uname -s") {
+		fmt.Println("Linux")
+		os.Exit(0)
+	} else if strings.Contains(args, "uname -m") {
+		os.Exit(0)
+	} else {
+		os.Exit(1)
+	}
+}
+
+func TestNamer(t *testing.T) {
+	t.Run("Computes triple with rustc", func(t *testing.T) {
+		injectFakeExec(t, "TestHelperRustcTriple")
+		n, err := createNamer()
+		assert.NilError(t, err)
+
+		bins := []*bin{{AssetPattern: "{triple}"}}
+		n.run(bins)
+
+		t.Log(bins[0].asset)
+	})
+
+	t.Run("Computes triple without rustc", func(t *testing.T) {
+		injectFakeExec(t, "TestHelperRustcFailed")
+		n, err := createNamer()
+		assert.NilError(t, err)
+
+		bins := []*bin{{AssetPattern: "{triple}"}}
+		n.run(bins)
+
+		t.Log(bins[0].asset)
+	})
+}

--- a/testdata/get.txtar
+++ b/testdata/get.txtar
@@ -219,8 +219,9 @@ stdout 'mod\tgithub\.com\/sevein\/perpignan\tv1\.0\.2'
         {
             "name": "jq",
             "url": "https://github.com/jqlang/jq",
-            "version": "jq-1.7.1",
+            "version": "1.7.1",
             "asset_pattern": "{name}-{goos}-{goarch}",
+            "tag_pattern": "{name}-{version}",
             "modifiers": {
               "goos": {
                 "darwin": "macos"


### PR DESCRIPTION
This pull request adds support for a new `{triple}` variable to be used in `asset_pattern` to work with projects using rusct "target triples" to name their assets. It also adds a new `tag_pattern` configuration attribute to match different naming conventions in SCM tags, e.g. `jq-1.8.0` (`{name}-{version}`) as opposed to `v1.8.0` (`v{version}`). With these changes, bine can now be used to dowload binaries from projects like jq or uv.