### PR TITLE
Honour tag_pattern when checking outdated deps

### DIFF
--- a/testdata/list.txtar
+++ b/testdata/list.txtar
@@ -31,9 +31,9 @@ cmp stdout ../list-outdated
 stderr 'performing request'
 
 # Discovers outdated Go binaries.
-setup .bine2.json
+setup .bine-go.json
 bine list --outdated
-cmp stdout ../list-outdated
+cmp stdout ../list-outdated-go
 ! stderr .
 
 -- .bine1.json --
@@ -46,9 +46,36 @@ cmp stdout ../list-outdated
 			"version": "1.0.0",
 			"asset_pattern": "{name}_{version}_{goos}_{goarch}"
 		},
+		{
+			"name": "fuuv",
+			"url": "https://github.com/sevein/fuuv",
+			"version": "1.0.0",
+			"asset_pattern": "{name}_{version}_{goos}_{goarch}",
+			"tag_pattern": "{version}"
+		},
 	]
 }
--- .bine2.json --
+-- list --
+perpignan v1.0.0
+fuuv v1.0.0
+-- list-installed --
+perpignan v1.0.0
+fuuv v1.0.0
+-- list-installed-json --
+[
+	{
+		"name": "perpignan",
+		"version": "v1.0.0"
+	},
+	{
+		"name": "fuuv",
+		"version": "v1.0.0"
+	}
+]
+-- list-outdated --
+perpignan v1.0.0 » v1.0.3
+fuuv v1.0.0 » v1.0.1
+-- .bine-go.json --
 {
     "project": "test",
     "bins": [
@@ -59,16 +86,5 @@ cmp stdout ../list-outdated
         }
     ]
 }
--- list --
-perpignan v1.0.0
--- list-installed --
-perpignan v1.0.0
--- list-installed-json --
-[
-	{
-		"name": "perpignan",
-		"version": "v1.0.0"
-	}
-]
--- list-outdated --
+-- list-outdated-go --
 perpignan v1.0.0 » v1.0.3


### PR DESCRIPTION
I noticed that bine wasn't able to list outdated deps when inspecting projects like uv tagged using semver but without the "v" prefix (e.g. https://github.com/astral-sh/uv/releases/tag/0.7.12). This pull request updated the outdated check to honour the tag pattern provided by the user, using regular expressions. The test scenario is built with https://github.com/sevein/fuuv - we can't test for `go_package` because it requires canonical semver tags :-).