### PR TITLE
Improve CLI verbosity UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ Core subcommands:
 
 Global flags:
 
-- `-v, --verbosity`: Increase log verbosity.
+- `-v, --verbose`: Increase log verbosity. Repeat as `-vv` or `-vvv`; `-vvv` is
+  the highest shorthand level we expect to need in practice.
+- `--verbosity=N`: Set the log verbosity level explicitly.
 - `--cache-dir`: Override the cache directory location.
 - `--github-api-token`: Provide a GitHub API token for authenticated requests.
 

--- a/cmd/rootcmd/rootcmd.go
+++ b/cmd/rootcmd/rootcmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/peterbourgon/ff/v4"
@@ -18,6 +19,7 @@ type RootConfig struct {
 	Stdout         io.Writer
 	Stderr         io.Writer
 	Verbosity      int
+	verboseCount   int
 	CacheDir       string
 	GitHubAPIToken string
 	Flags          *ff.FlagSet
@@ -31,7 +33,8 @@ func New(stdin io.Reader, stdout, stderr io.Writer) *RootConfig {
 	cfg.Stdout = stdout
 	cfg.Stderr = stderr
 	cfg.Flags = ff.NewFlagSet("bine")
-	cfg.Flags.IntVar(&cfg.Verbosity, 'v', "verbosity", -1, "Log verbosity level. The higher the number, the more verbose the output.")
+	cfg.Flags.Value('v', "verbose", (*verbosityCountValue)(&cfg.verboseCount), "Increase log verbosity. Repeat up to -vvv for the highest shorthand level.")
+	cfg.Flags.IntVar(&cfg.Verbosity, 0, "verbosity", 0, "Set the log verbosity level explicitly.")
 	cfg.Flags.StringVar(&cfg.CacheDir, 0, "cache-dir", "", "Path to the cache directory.")
 	cfg.Flags.StringVar(&cfg.GitHubAPIToken, 0, "github-api-token", "", "GitHub API token for authentication.")
 	cfg.Command = &ff.Command{
@@ -48,6 +51,13 @@ ensuring you have the right versions without cluttering your system.`,
 	return &cfg
 }
 
+func (cfg *RootConfig) ResolveVerbosity() {
+	if flag, ok := cfg.Flags.GetFlag("verbosity"); ok && flag.IsSet() {
+		return
+	}
+	cfg.Verbosity = cfg.verboseCount
+}
+
 func (cfg *RootConfig) Exec(_ context.Context, args []string) error {
 	if len(args) > 0 {
 		fmt.Fprintf(cfg.Stdout, "%s\n", ffhelp.Command(cfg.Command))
@@ -57,4 +67,36 @@ func (cfg *RootConfig) Exec(_ context.Context, args []string) error {
 	fmt.Fprintf(cfg.Stdout, "%s\n", ffhelp.Command(cfg.Command))
 
 	return ff.ErrHelp
+}
+
+// verbosityCountValue implements flag.Value for the repeatable -v/--verbose
+// shorthand. ff treats values with IsBoolFlag as boolean flags, which lets
+// clustered forms like -vv and repeated long forms like --verbose --verbose
+// increment the counter once per occurrence.
+type verbosityCountValue int
+
+func (v *verbosityCountValue) String() string {
+	if v == nil {
+		return "0"
+	}
+	return strconv.Itoa(int(*v))
+}
+
+func (v *verbosityCountValue) Set(value string) error {
+	switch value {
+	case "", "true":
+		*v = *v + 1
+		return nil
+	case "false":
+		*v = 0
+		return nil
+	default:
+		return fmt.Errorf("invalid boolean value %q", value)
+	}
+}
+
+// IsBoolFlag tells ff to parse -v and --verbose without requiring an explicit
+// value, while still routing each occurrence through Set.
+func (v *verbosityCountValue) IsBoolFlag() bool {
+	return true
 }

--- a/cmd/rootcmd/rootcmd_test.go
+++ b/cmd/rootcmd/rootcmd_test.go
@@ -1,0 +1,48 @@
+package rootcmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestResolveVerbosity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		verbosity int
+		wantErr   string
+	}{
+		{name: "default", verbosity: 0},
+		{name: "single verbose", args: []string{"-v"}, verbosity: 1},
+		{name: "double verbose", args: []string{"-vv"}, verbosity: 2},
+		{name: "triple verbose", args: []string{"-vvv"}, verbosity: 3},
+		{name: "long verbose", args: []string{"--verbose", "--verbose"}, verbosity: 2},
+		{name: "explicit verbosity", args: []string{"--verbosity=2"}, verbosity: 2},
+		{name: "explicit verbosity wins", args: []string{"-vv", "--verbosity=1"}, verbosity: 1},
+		{name: "explicit zero wins", args: []string{"-vv", "--verbosity=0"}, verbosity: 0},
+		{name: "verbose rejects explicit value", args: []string{"--verbose=2"}, wantErr: "invalid boolean value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := New(strings.NewReader(""), io.Discard, io.Discard)
+			err := cfg.Command.Parse(tt.args)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			cfg.ResolveVerbosity()
+
+			assert.Equal(t, cfg.Verbosity, tt.verbosity)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func exec(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io
 		fmt.Fprintf(stderr, "\n%s\n", ffhelp.Command(root.Command))
 		return err
 	}
+	root.ResolveVerbosity()
 
 	var logger logr.Logger
 	if root.Verbosity > 0 {

--- a/testdata/list.txtar
+++ b/testdata/list.txtar
@@ -25,7 +25,18 @@ bine list --installed --json
 cmp stdout ../list-installed-json
 ! stderr .
 
-# Discovers outdated binaries.
+# Discovers outdated binaries with repeated verbosity flags.
+bine list --outdated -vv
+cmp stdout ../list-outdated
+stderr 'performing request'
+
+# Single verbose mode emits V(1) logs but not request tracing.
+bine list --outdated -v
+cmp stdout ../list-outdated
+stderr 'Starting bine.'
+! stderr 'performing request'
+
+# Explicit verbosity remains supported.
 bine list --outdated --verbosity=2
 cmp stdout ../list-outdated
 stderr 'performing request'


### PR DESCRIPTION
Add a repeatable -v/--verbose shorthand while keeping --verbosity=N for explicit levels. Document the new behavior, clarify that -vvv is the highest shorthand level we expect to need, and cover the parsing rules in tests.